### PR TITLE
Added links to all book titles

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -218,4 +218,4 @@ DEPENDENCIES
   web-console (>= 3.3.0)
 
 BUNDLED WITH
-   1.17.1
+   2.0.1

--- a/app/views/authors/show.html.erb
+++ b/app/views/authors/show.html.erb
@@ -2,7 +2,7 @@
 
 <% @author.books.each do |book| %>
   <section id="book-<%= book.id %>">
-    <p><%= book.title %></p>
+    <p><%= link_to book.title, book_path(book) %></p>
     <img src="<%= book.image_url %>" alt="<%= book.id %>">
     <% book.authors.each do |author| %>
       <p><%= author.name unless author.name == @author.name %></p>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,7 +1,7 @@
 <% @user.reviews.each do |review| %>
   <section id="review-<%= review.id %>">
     <h3><%= review.title %></h3>
-    <h4><%= review.book.title %></h4>
+    <h4><%= link_to review.book.title, book_path(review.book) %></h4>
     <img src="<%= review.book.image_url %>" alt="<%= review.book.title %>">
     <p>Rating: <%= review.rating %></p>
     <p><%= review.text %></p>

--- a/spec/features/authors/author_show_spec.rb
+++ b/spec/features/authors/author_show_spec.rb
@@ -30,4 +30,12 @@ RSpec.describe 'author show page' do
       expect(page).to_not have_content(@author.name)
     end
   end
+
+  it 'shows a book title that is a link to the book show page' do
+    visit author_path(@author)
+
+    click_link "#{@book_1.title}"
+
+    expect(current_path).to eq(book_path(@book_1))
+  end
 end

--- a/spec/features/books/books_index_spec.rb
+++ b/spec/features/books/books_index_spec.rb
@@ -146,19 +146,12 @@ RSpec.describe 'when a visitor visits the books index page' do
     expect(page.all('.individual-book')[1]).to have_content(@book_2.title)
     expect(page.all('.individual-book')[2]).to have_content(@book_3.title)
   end
+
+  it 'shows a book title that is a link to the book show page' do
+    visit books_path
+
+    click_link "#{@book_1.title}"
+
+    expect(current_path).to eq(book_path(@book_1))
+  end
 end
-
-# As a Visitor,
-# When I visit the book index page,
-# Next to each book title, I see its average book rating
-# And I also see the total number of reviews for the book.
-
-# As a Visitor,
-# When I visit the book index page,
-# I should see one link each to sort the books by the following criteria:
-# - sorted by average rating in ascending order
-# - sorted by average rating in descending order
-# - sorted by number of pages in ascending order
-# - sorted by number of pages in descending order
-# - sorted by number of reviews in ascending order
-# - sorted by number of reviews in descending order

--- a/spec/features/books/user_can_add_a_new_book_spec.rb
+++ b/spec/features/books/user_can_add_a_new_book_spec.rb
@@ -48,88 +48,73 @@ RSpec.describe 'When the user clicks on new book button', type: :feature do
       end
 
       it 'should render the form again if fields are empty' do
-         visit new_book_path
+        visit new_book_path
 
-         click_button 'Create Book'
+        click_button 'Create Book'
 
-         expect(page).to have_button('Create Book')
-         expect(page).to have_field("book[title]")
-         within "#errors"
-            ["Title can't be blank",
-             "Authors can't be blank",
-             "Pages can't be blank",
+        expect(page).to have_button('Create Book')
+        expect(page).to have_field("book[title]")
+        within "#errors"
+          ["Title can't be blank",
+           "Authors can't be blank",
+           "Pages can't be blank",
 
-             "Pages is not a number",
-             "Year published can't be blank",
-             "Year published is not a number"].each do |msg|
+           "Pages is not a number",
+           "Year published can't be blank",
+           "Year published is not a number"].each do |msg|
 
-           expect(page).to have_content(msg)
-         end
-       end
+          expect(page).to have_content(msg)
+        end
+      end
 
-       it 'should default to a book image with an empty image field' do
-         author_1 = Author.create(name: "JRR Tokien")
-         book_1 = author_1.books.create(title: "Lord of the Rings", pages: 1000, year_published: 1955)
-         default_image = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAOEAAADhCAMAAAAJbSJIAAAAflBMVEX/xJz////bmWyhakr/1bigaEefZkS3kX2oeFydYj/TvrOaY0P5v5f/yKLal2nosIqudVKbXjjt5eGocVHgp4PIiWGoc1T/277gs5fn29XNs6XCoZCaXDb59fO5k3+wg2vdzcXZxbvFp5fPt6qxhW7q39rTk2n28e67f1rRmXacEEpjAAAC7ElEQVR4nO3YbXeaMBiAYYEFja6bkdXON9B1uu7//8FJ7Npz1hP0kHRPQu/7a9qe52oCgqNs6I2kB3j3EKYfwvRDmH4I0w/hS7v9uq7HMbf3Eh4aY3QZdWbqITwUWhWxp/sLd42J3+cjXJSl9PA31Vt43L5sYGUrqmVbFVM+wl/PV+Bsfp9f+vL1oe0uokYzD+HkckSrU56/Cj+duxvF02cP4dRY4DzPhyrUFviUD1b4aIVVPlzh0t5mTsMVLrb/XoRDE0712y0clnBjPyryAQsb9faQDks4QRhJCBEilA8hQoTyIUSIUD6ECBHKhxAhQvkQIkQoH0KECOVDiBChfAgRIpQPIUKE8iFEiFA+hAgRyocQIUL5ECJEKB9ChAjlQ4gQoXwIESKUDyFChPIhRIhQPoQIEcqHECFC+RAiRCgfQoQI5UOIEKF8CBEilA8hQoTyIUSIUD6ECBHKhxAhQvkQIkQoH0KECOVDiBChfAgRIpQPIUKE8iFEiFA+hAgRyocQIUL5ECJEKB9ChB9U+BCR8C6M8HT/t9/f277FlLfw9FQVr6lZdBWewvmsSKD+wurq346j/sJU8hWW2kSbDiAs9Wa/WsTayhK3Kw+hqXddPybduhWWG8fqLcLtIfxUIVu2YxrXJtwg1Ot3mCpgi23XFt4gVE34oYI2bQ+pcVyFtwi183cjaVO2UzqXrwtN8JEC15ynVBPn8lWh+hl8pMBV5ynL2rl8VViOg48UuKLzRjOEPSw89nDcXsMq+EiBs/vgvuF3Cu3DglkEnylstce9dGW6j3gcXdmHTmFm7FPpMfhQQbP7oB9dy93CH+2/R5VRP3dnmR1y6VrtFu7sJqoi7scaeyGavWO1W5hNL8TtOOaTurCbqBwn7YowG19eoEujlpNoU73f8dsa/fyer+Kt/7cYttp4f0n0X+ovPL9/6RS+c/MQZrv10ugy9oyH8NxxuqnHkef4uLhRmHAI0w9h+iFMP4TphzD9/gAYrjykfbvuxgAAAABJRU5ErkJggg=='
+      it 'should default to a book image with an empty image field' do
+        author_1 = Author.create(name: "JRR Tokien")
+        book_1 = author_1.books.create(title: "Lord of the Rings", pages: 1000, year_published: 1955)
+        default_image = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAOEAAADhCAMAAAAJbSJIAAAAflBMVEX/xJz////bmWyhakr/1bigaEefZkS3kX2oeFydYj/TvrOaY0P5v5f/yKLal2nosIqudVKbXjjt5eGocVHgp4PIiWGoc1T/277gs5fn29XNs6XCoZCaXDb59fO5k3+wg2vdzcXZxbvFp5fPt6qxhW7q39rTk2n28e67f1rRmXacEEpjAAAC7ElEQVR4nO3YbXeaMBiAYYEFja6bkdXON9B1uu7//8FJ7Npz1hP0kHRPQu/7a9qe52oCgqNs6I2kB3j3EKYfwvRDmH4I0w/hS7v9uq7HMbf3Eh4aY3QZdWbqITwUWhWxp/sLd42J3+cjXJSl9PA31Vt43L5sYGUrqmVbFVM+wl/PV+Bsfp9f+vL1oe0uokYzD+HkckSrU56/Cj+duxvF02cP4dRY4DzPhyrUFviUD1b4aIVVPlzh0t5mTsMVLrb/XoRDE0712y0clnBjPyryAQsb9faQDks4QRhJCBEilA8hQoTyIUSIUD6ECBHKhxAhQvkQIkQoH0KECOVDiBChfAgRIpQPIUKE8iFEiFA+hAgRyocQIUL5ECJEKB9ChAjlQ4gQoXwIESKUDyFChPIhRIhQPoQIEcqHECFC+RAiRCgfQoQI5UOIEKF8CBEilA8hQoTyIUSIUD6ECBHKhxAhQvkQIkQoH0KECOVDiBChfAgRIpQPIUKE8iFEiFA+hAgRyocQIUL5ECJEKB9ChB9U+BCR8C6M8HT/t9/f277FlLfw9FQVr6lZdBWewvmsSKD+wurq346j/sJU8hWW2kSbDiAs9Wa/WsTayhK3Kw+hqXddPybduhWWG8fqLcLtIfxUIVu2YxrXJtwg1Ot3mCpgi23XFt4gVE34oYI2bQ+pcVyFtwi183cjaVO2UzqXrwtN8JEC15ynVBPn8lWh+hl8pMBV5ynL2rl8VViOg48UuKLzRjOEPSw89nDcXsMq+EiBs/vgvuF3Cu3DglkEnylstce9dGW6j3gcXdmHTmFm7FPpMfhQQbP7oB9dy93CH+2/R5VRP3dnmR1y6VrtFu7sJqoi7scaeyGavWO1W5hNL8TtOOaTurCbqBwn7YowG19eoEujlpNoU73f8dsa/fyer+Kt/7cYttp4f0n0X+ovPL9/6RS+c/MQZrv10ugy9oyH8NxxuqnHkef4uLhRmHAI0w9h+iFMP4TphzD9/gAYrjykfbvuxgAAAABJRU5ErkJggg=='
 
-         visit new_book_path
+        visit new_book_path
 
-         fill_in "book[title]", with: "The Wizard of Oz"
-         fill_in "book[authors]", with: "L. Frank Baum"
-         fill_in "book[pages]", with: 100
-         fill_in "book[year_published]", with: 1900
+        fill_in "book[title]", with: "The Wizard of Oz"
+        fill_in "book[authors]", with: "L. Frank Baum"
+        fill_in "book[pages]", with: 100
+        fill_in "book[year_published]", with: 1900
 
-         click_button 'Create Book'
+        click_button 'Create Book'
 
-         expect(page).to have_css("img[src*='#{default_image}']")
-       end
+        expect(page).to have_css("img[src*='#{default_image}']")
+      end
 
-       it "should accept multiple authors" do
-         visit new_book_path
+      it "should accept multiple authors" do
+        visit new_book_path
 
-         fill_in "book[title]", with: "The Wizard of Oz"
-         fill_in "book[authors]", with: "L. Frank Baum, SCOTT thomas"
-         fill_in "book[pages]", with: 100
-         fill_in "book[year_published]", with: 1900
-         fill_in "book[image_url]", with: "https://images-na.ssl-images-amazon.com/images/I/81lAPl9Fl0L.jpg"
+        fill_in "book[title]", with: "The Wizard of Oz"
+        fill_in "book[authors]", with: "L. Frank Baum, SCOTT thomas"
+        fill_in "book[pages]", with: 100
+        fill_in "book[year_published]", with: 1900
+        fill_in "book[image_url]", with: "https://images-na.ssl-images-amazon.com/images/I/81lAPl9Fl0L.jpg"
 
-         click_button 'Create Book'
+        click_button 'Create Book'
 
-         expect(page).to have_content("L. Frank Baum")
-         expect(page).to have_content("Scott Thomas")
-       end
+        expect(page).to have_content("L. Frank Baum")
+        expect(page).to have_content("Scott Thomas")
+      end
 
-       xit "should not create a duplicate author" do
-         author_1 = Author.create("L. Frank Baum")
-         book_1 = Book.create(authors: author_1, title: 'googley goo', pages: 200, year_published: 2003)
+      it "should not create a duplicate book" do
+        author_1 = Author.create(name: "L. Frank Baum")
+        book_1 = Book.create(authors: [author_1], title: 'The Wizard of Oz', pages: 200, year_published: 2003)
 
-         visit new_book_path
+        visit new_book_path
 
-         fill_in "book[title]", with: "The Wizard of Oz"
-         fill_in "book[authors]", with: "L. Frank Baum, SCOTT thomas"
-         fill_in "book[pages]", with: 100
-         fill_in "book[year_published]", with: 1900
-         fill_in "book[image_url]", with: "https://images-na.ssl-images-amazon.com/images/I/81lAPl9Fl0L.jpg"
+        fill_in "book[title]", with: "The Wizard of Oz"
+        fill_in "book[authors]", with: "L. Frank Baum, SCOTT thomas"
+        fill_in "book[pages]", with: 100
+        fill_in "book[year_published]", with: 1900
+        fill_in "book[image_url]", with: "https://images-na.ssl-images-amazon.com/images/I/81lAPl9Fl0L.jpg"
 
-         click_button 'Create Book'
-       end
+        click_button 'Create Book'
 
-     it "should not create a duplicate book" do
-       author_1 = Author.create(name: "L. Frank Baum")
-       book_1 = Book.create(authors: [author_1], title: 'The Wizard of Oz', pages: 200, year_published: 2003)
-
-       visit new_book_path
-
-       fill_in "book[title]", with: "The Wizard of Oz"
-       fill_in "book[authors]", with: "L. Frank Baum, SCOTT thomas"
-       fill_in "book[pages]", with: 100
-       fill_in "book[year_published]", with: 1900
-       fill_in "book[image_url]", with: "https://images-na.ssl-images-amazon.com/images/I/81lAPl9Fl0L.jpg"
-
-       click_button 'Create Book'
-
-       expect(page).to have_button('Create Book')
-       expect(page).to have_field("book[title]")
+        expect(page).to have_button('Create Book')
+        expect(page).to have_field("book[title]")
       end
     end
   end

--- a/spec/features/reviews/new_review_spec.rb
+++ b/spec/features/reviews/new_review_spec.rb
@@ -35,5 +35,15 @@ RSpec.describe 'When the user clicks on new review button', type: :feature do
     expect(current_path).to eq(book_path(@book_1))
   end
 
+  it 're-renders the page if fields are empty' do
+    visit new_book_review_path(@book_1)
 
+    fill_in "review[title]", with: "Great Book"
+    fill_in "review[user]", with: "BookLuvr"
+    fill_in "review[rating]", with: 5
+
+    click_button "Create Review"
+
+    expect(page).to have_button("Create Review")
+  end
 end

--- a/spec/features/users/user_show_spec.rb
+++ b/spec/features/users/user_show_spec.rb
@@ -64,5 +64,22 @@ RSpec.describe 'user show page' do
         expect(page).to have_content("Date: 2019-02-03")
       end
     end
+
+    it 'shows a book title that is a link to the book show page' do
+      visit new_book_review_path(@book_1)
+
+      fill_in "review[title]", with: "Great Book"
+      fill_in "review[user]", with: "Book luvr"
+      fill_in "review[text]", with: "This was a great book."
+      fill_in "review[rating]", with: 5
+
+      click_button "Create Review"
+
+      visit user_path(@user)
+
+      click_link "#{@book_1.title}"
+
+      expect(current_path).to eq(book_path(@book_1))
+    end
   end
 end


### PR DESCRIPTION
As a visitor
With the exception of a book's show page,
Anywhere I see a book title on the site,
I can click on the book title to go to that book's show page.

Co-authored by: Scott Thomas <31359242+smthom05@users.noreply.github.com>