### PR TITLE
Added link that deletes a review.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -218,4 +218,4 @@ DEPENDENCIES
   web-console (>= 3.3.0)
 
 BUNDLED WITH
-   2.0.1
+   1.17.1

--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -18,6 +18,13 @@ class ReviewsController < ApplicationController
     end
   end
 
+  def destroy
+    user_id = Review.find(params[:id]).user_id
+    Review.find(params[:id]).destroy
+
+    redirect_to user_path(user_id)
+  end
+
   private
 
   def review_params

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -6,5 +6,6 @@
     <p>Rating: <%= review.rating %></p>
     <p><%= review.text %></p>
     <p>Date: <%= review.created_at %></p>
+    <%= link_to "Delete Review", review_path(review), method: :delete %>
   </section>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,5 +9,7 @@ Rails.application.routes.draw do
 
   resources :authors
 
+  resources :reviews, only: [:destroy]
+
   resources :users, only: [:show]
 end

--- a/spec/features/authors/author_show_spec.rb
+++ b/spec/features/authors/author_show_spec.rb
@@ -7,6 +7,8 @@ RSpec.describe 'author show page' do
     @book_1 = Book.create(authors: [@author, @author_2], title: "Fellowship", pages: 400, year_published: 1954, image_url: "https://images-na.ssl-images-amazon.com/images/I/51tW-UJVfHL._SX321_BO1,204,203,200_.jpg")
     @book_2 = Book.create(authors: [@author, @author_2], title: "Towers", pages: 300, year_published: 1955, image_url: "https://images-na.ssl-images-amazon.com/images/I/4123zOAwAgL.jpg")
     @book_3 = Book.create(authors: [@author, @author_2], title: "King", pages: 500, year_published: 1956, image_url: "https://images-na.ssl-images-amazon.com/images/I/41fHC5yiRgL.jpg")
+    @book_4 = Book.create(authors: @author, title: "Something", pages: 200, year_published: 1957)
+    @book_5 = Book.create(authors: @author_2, title: "Something else", pages: 100, year_published: 1958)
   end
 
   it 'shows me all books by the author' do
@@ -37,5 +39,9 @@ RSpec.describe 'author show page' do
     click_link "#{@book_1.title}"
 
     expect(current_path).to eq(book_path(@book_1))
+  end
+
+  it 'shows a link that deletes the author and all of his or her books' do
+
   end
 end

--- a/spec/features/users/user_show_spec.rb
+++ b/spec/features/users/user_show_spec.rb
@@ -8,33 +8,20 @@ RSpec.describe 'user show page' do
       @book_1 = Book.create(authors: [author_1], title: "Lord of the Rings", pages: 1000, year_published: 1955, image_url: "https://upload.wikimedia.org/wikipedia/en/e/e9/First_Single_Volume_Edition_of_The_Lord_of_the_Rings.gif")
       author_2 = Author.create(name: "JK Rowling")
       @book_2 = Book.create(authors: [author_2], title: "The Prisoner of Azkaban", pages: 400, year_published: 1999, image_url: "https://images-na.ssl-images-amazon.com/images/I/81lAPl9Fl0L.jpg")
+      @review = @book_1.reviews.create(title: "Review Example", rating: 5, text: "jfadlskjf;kf", user: @user)
     end
 
     it 'takes me to a users show page' do
-      visit new_book_review_path(@book_1)
+      visit book_path(@book_1)
 
-      fill_in "review[title]", with: "Great Book"
-      fill_in "review[user]", with: "Book luvr"
-      fill_in "review[text]", with: "This was a great book."
-      fill_in "review[rating]", with: 5
-
-      click_button "Create Review"
-
-      click_link "Book Luvr"
+      within "#review-#{@review.id}" do
+        click_link "Book Luvr"
+      end
 
       expect(current_path).to eq(user_path(@user))
     end
 
     it 'shows me all the users reviews' do
-      visit new_book_review_path(@book_1)
-
-      fill_in "review[title]", with: "Great Book"
-      fill_in "review[user]", with: "Book luvr"
-      fill_in "review[text]", with: "This was a great book."
-      fill_in "review[rating]", with: 5
-
-      click_button "Create Review"
-
       visit new_book_review_path(@book_2)
 
       fill_in "review[title]", with: "Best Book"
@@ -52,7 +39,7 @@ RSpec.describe 'user show page' do
         expect(page).to have_content(@user.reviews[0].rating)
         expect(page).to have_content(@book_1.title)
         expect(page).to have_css("img[src*='#{@book_1.image_url}']")
-        expect(page).to have_content("Date: 2019-02-03")
+        expect(page).to have_content(@book_1.created_at)
       end
 
       within "#review-#{@user.reviews[1].id}" do
@@ -61,25 +48,29 @@ RSpec.describe 'user show page' do
         expect(page).to have_content(@user.reviews[1].rating)
         expect(page).to have_content(@book_2.title)
         expect(page).to have_css("img[src*='#{@book_2.image_url}']")
-        expect(page).to have_content("Date: 2019-02-03")
+        expect(page).to have_content(@book_2.created_at)
       end
     end
 
     it 'shows a book title that is a link to the book show page' do
-      visit new_book_review_path(@book_1)
-
-      fill_in "review[title]", with: "Great Book"
-      fill_in "review[user]", with: "Book luvr"
-      fill_in "review[text]", with: "This was a great book."
-      fill_in "review[rating]", with: 5
-
-      click_button "Create Review"
-
       visit user_path(@user)
 
-      click_link "#{@book_1.title}"
+      within "#review-#{@review.id}" do
+        click_link "#{@book_1.title}"
+      end
 
       expect(current_path).to eq(book_path(@book_1))
+    end
+
+    it 'can delete an exisiting review' do
+      visit user_path(@user)
+
+      within "#review-#{@review.id}" do
+        click_link "Delete Review"
+      end
+
+      expect(current_path).to eq(user_path(@user))
+      expect(page).to_not have_content(@review.title)
     end
   end
 end


### PR DESCRIPTION
User Story 18
As a Visitor,
When I visit a user's show page,
I see a link next to each review to delete the review.
When I delete a review I am returned to the user's show page
Then I should no longer see that review.

Co-authored-by: Tim Allen <42568362+allen4397@users.noreply.github.com>