### PR TITLE
User Story 19

### DIFF
--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -46,6 +46,14 @@ class BooksController < ApplicationController
     end
   end
 
+  def destroy
+    Review.where(book_id: params[:id]).destroy_all
+    BookAuthor.where(book_id: params[:id]).destroy_all
+    Book.find(params[:id]).destroy
+
+    redirect_to books_path
+  end
+
   private
   def book_params
     params.require(:book).permit(:title, :authors, :pages, :year_published, :image_url)

--- a/app/views/books/show.html.erb
+++ b/app/views/books/show.html.erb
@@ -8,7 +8,7 @@
   <img src="<%= @book.image_url %>" alt="<%= @book.title %>">
   <p>Pages: <%= @book.pages %></p>
   <p>Year Published: <%= @book.year_published %></p>
-  
+
   <p> <%= link_to "Add New Review", new_book_review_path(@book) %> </p>
 
   <% @book.reviews.each do |review| %>
@@ -20,5 +20,5 @@
     </section>
   <% end %>
 
-
+  <%= link_to "Delete Book", book_path(@book), method: :delete %>
 </section>

--- a/spec/features/books/book_show_spec.rb
+++ b/spec/features/books/book_show_spec.rb
@@ -40,4 +40,19 @@ RSpec.describe 'when a visitor visits a book show page' do
       expect(page).to have_content("User Name: #{user_2.name}")
     end
   end
+
+  it 'shows a link to delete a book and it that book no longer appears on book index page' do
+    author_1 = Author.create(name: "JRR Tolkien")
+    author_2 = Author.create(name: "JK Rowling")
+    book_1 = Book.create(authors: [author_1], title: "Lord of the Rings", pages: 1000, year_published: 1955, image_url: "https://upload.wikimedia.org/wikipedia/en/e/e9/First_Single_Volume_Edition_of_The_Lord_of_the_Rings.gif")
+    book_2 = Book.create(authors: [author_2], title: "The Prisoner of Azkaban", pages: 400, year_published: 1999, image_url: "https://images-na.ssl-images-amazon.com/images/I/81lAPl9Fl0L.jpg")
+
+    visit book_path(book_1)
+
+    click_link "Delete Book"
+
+    expect(current_path).to eq(books_path)
+    expect(page).to have_content(book_2.title)
+    expect(page).to_not have_content(book_1.title)
+  end
 end


### PR DESCRIPTION
As a Visitor,
When I visit a book's show page,
I see a link on the page to delete the book.
This link should return me to the book index page where I
no longer see this book listed.

(your controller may need to delete other content before you can delete the book)

Co-authored-by: Tim Allen <42568362+allen4397@users.noreply.github.com>