### PR TITLE
Adds book show page statistics (average rating, top and bottom 3 reviews

### DIFF
--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -14,6 +14,8 @@ class BooksController < ApplicationController
 
   def show
     @book = Book.find(params[:id])
+    @top_reviews = @book.top_reviews
+    @bottom_reviews = @book.bottom_reviews
   end
 
   def new

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -51,4 +51,12 @@ class Book < ApplicationRecord
       Book.left_joins(:reviews).group(:id).order('reviews.count desc')
     end
   end
+
+  def top_reviews
+    reviews.order(rating: :desc).limit(3)
+  end
+
+  def bottom_reviews
+    reviews.order(:rating).limit(3)
+  end
 end

--- a/app/views/books/show.html.erb
+++ b/app/views/books/show.html.erb
@@ -11,6 +11,26 @@
 
   <p> <%= link_to "Add New Review", new_book_review_path(@book) %> </p>
 
+  <section id="statistics">
+    <h4 id="average-rating">Average Rating: <%= @book.average_rating %></h4>
+
+    <% @top_reviews.each do |review| %>
+      <div id="top-review-<%= review.id %>">
+        <h4><%= review.title %></h4>
+        <p><%= review.rating %></p>
+        <p><%= link_to review.user.name, user_path(review.user) %></p>
+      </div>
+    <% end %>
+
+    <% @bottom_reviews.each do |review| %>
+      <div id="bottom-review-<%= review.id %>">
+        <h4><%= review.title %></h4>
+        <p><%= review.rating %></p>
+        <p><%= link_to review.user.name, user_path(review.user) %></p>
+      </div>
+    <% end %>
+  </section>
+
   <% @book.reviews.each do |review| %>
     <section id="review-<%= review.id %>">
       <p>Title:  <%= review.title %> </p>

--- a/spec/features/books/book_show_spec.rb
+++ b/spec/features/books/book_show_spec.rb
@@ -69,4 +69,88 @@ RSpec.describe 'when a visitor visits a book show page' do
 
     expect(current_path).to eq(author_path(author_1))
   end
+
+  describe 'in the area for statistics' do
+    before :each do
+      @author_1 = Author.create(name: "JRR Tolkien")
+      @book_1 = Book.create!(authors: [@author_1], title: "Lord of the Rings", pages: 1000, year_published: 1955)
+      @user_1 = User.create(name: "LOTRfan1ring")
+      @user_2 = User.create(name: "LOTRhater")
+      @review_1 = @user_1.reviews.create(title: "Once", text: "This book had hobbits, orcs, elves, and all good stuff. Must read!", rating: 1, book: @book_1)
+      @review_2 = @user_2.reviews.create(title: "Twice", text: "This book had nothing good about it. Stay Away!", rating: 2, book: @book_1)
+      @review_3 = @user_1.reviews.create(title: "Thrice", text: "another test", rating: 3, book: @book_1)
+      @review_4 = @user_1.reviews.create(title: "uhhh four", text: "gdhjkfghs", rating: 4, book: @book_1)
+      @review_5 = @user_1.reviews.create(title: "five", text: "bfhjkdslghl", rating: 5, book: @book_1)
+    end
+
+    it 'shows the top three reviews (title, rating and user) for this book' do
+      visit book_path(@book_1)
+
+      within "#statistics" do
+        within "#top-review-#{@review_5.id}" do
+          expect(page).to have_content(@review_5.title)
+          expect(page).to have_content(@review_5.rating)
+          expect(page).to have_content(@review_5.user.name)
+        end
+
+        within "#top-review-#{@review_4.id}" do
+          expect(page).to have_content(@review_4.title)
+          expect(page).to have_content(@review_4.rating)
+          expect(page).to have_content(@review_4.user.name)
+        end
+
+        within "#top-review-#{@review_3.id}" do
+          expect(page).to have_content(@review_3.title)
+          expect(page).to have_content(@review_3.rating)
+          expect(page).to have_content(@review_3.user.name)
+        end
+      end
+    end
+
+    it 'shows the bottom three reviews (title, rating and user) for this book' do
+      visit book_path(@book_1)
+
+      within "#statistics" do
+        within "#bottom-review-#{@review_1.id}" do
+          expect(page).to have_content(@review_1.title)
+          expect(page).to have_content(@review_1.rating)
+          expect(page).to have_content(@review_1.user.name)
+        end
+
+        within "#bottom-review-#{@review_2.id}" do
+          expect(page).to have_content(@review_2.title)
+          expect(page).to have_content(@review_2.rating)
+          expect(page).to have_content(@review_2.user.name)
+        end
+
+        within "#bottom-review-#{@review_3.id}" do
+          expect(page).to have_content(@review_3.title)
+          expect(page).to have_content(@review_3.rating)
+          expect(page).to have_content(@review_3.user.name)
+        end
+      end
+    end
+
+    it 'shows the visitor the overall average of all reviews for this book' do
+      visit book_path(@book_1)
+
+      within '#statistics' do
+        within '#average-rating' do
+          expect(page).to have_content("Average Rating: #{@book_1.average_rating}")
+        end
+      end
+    end
+
+    it 'takes the visitor to a user show page when they click the user name' do
+      visit book_path(@book_1)
+
+      within "#statistics" do
+        within "#top-review-#{@review_5.id}" do
+          click_link "#{@review_5.user.name}"
+        end
+      end
+
+      expect(current_path).to eq(user_path(@user_1))
+    end
+  end
 end

--- a/spec/models/book_spec.rb
+++ b/spec/models/book_spec.rb
@@ -61,23 +61,32 @@ RSpec.describe Book, type: :model do
       @review_3 = @book_2.reviews.create(title: "Review 1 Book 2", rating: 3, text: "Faker", user: @user)
       @review_4 = @book_2.reviews.create(title: "Review 2 Book 2", rating: 1, text: "Fakest", user: @user)
       @review_5 = @book_2.reviews.create(title: "Review 3 Book 2", rating: 2, text: "Fakest by far", user: @user)
+      @review_6 = @book_2.reviews.create(title: "Review 4 Book 2", rating: 5, text: "Fakest by far", user: @user)
+
     end
 
     it '.average_rating' do
       expect(@book_1.average_rating).to eq(3)
-      expect(@book_2.average_rating).to eq(2)
       expect(@book_3.average_rating).to eq(0)
     end
 
     it '.number_of_reviews' do
       expect(@book_1.number_of_reviews).to eq(2)
-      expect(@book_2.number_of_reviews).to eq(3)
+      expect(@book_2.number_of_reviews).to eq(4)
       expect(@book_3.number_of_reviews).to eq(0)
     end
 
     it '.top_review' do
       expect(@book_1.top_review).to eq(@review_1)
-      expect(@book_2.top_review).to eq(@review_3)
+      expect(@book_2.top_review).to eq(@review_6)
+    end
+
+    it '.top_reviews' do
+      expect(@book_2.top_reviews).to eq([@review_6, @review_3, @review_5])
+    end
+
+    it '.bottom_reviews' do
+      expect(@book_2.bottom_reviews).to eq([@review_4, @review_5, @review_3])
     end
   end
 end


### PR DESCRIPTION
As a Visitor,
When I visit a book's show page,
I see an area on the page for statistics about reviews:
- the top three reviews for this book (title, rating and user only)
- the bottom three reviews for this book  (title, rating and user only)
- the overall average rating of all reviews for this book

Co-authored by: Scott Thomas <31359242+smthom05@users.noreply.github.com>